### PR TITLE
Update runonlydrfs

### DIFF
--- a/runonlydrfs.sh
+++ b/runonlydrfs.sh
@@ -14,8 +14,8 @@ dotdate=2026.03.09
 tileid=h09v05
 product=MOD09GA
 
-workdir=/scratch/alpine/${operator_username}/scagdrfs/working/${dotdate}/${tileid}
-# workdir=/scratch/alpine/${operator_username}/scagdrfs/working/${product}/${dotdate}/${tileid}
+# workdir=/scratch/alpine/${operator_username}/scagdrfs/working/${dotdate}/${tileid}
+workdir=/scratch/alpine/${operator_username}/scagdrfs/working/${product}/${dotdate}/${tileid}
 hdf_bfn=MOD09GA.A2026068.h09v05.061.2026069014006.NRT.hdf
 hdf_ffn=${workdir}/${hdf_bfn}
 

--- a/src/run_drfs_idl.py
+++ b/src/run_drfs_idl.py
@@ -89,6 +89,12 @@ def run_drfs_idl_via_bash(hdf_file, component_dir, working_dir):
 
     # Get information from the BIP metadata file.
     meta_path = Path(str(hdf_file).replace(hdf_file.suffix, ".bip.meta"))
+
+    # Create the .bip and .bip_meta file if it does not exist
+    if not meta_path.is_file():
+        from scag.scripts.BIPifier import bipify_file
+        bip_path = Path(str(hdf_file).replace(hdf_file.suffix, ".bip"))
+        bipify_file(hdf_file, bip_path)
     meta_content = None
     with meta_path.open() as meta_file:
         meta_content = meta_file.read()


### PR DESCRIPTION
This updates the `runonlydrfs.sh` script to run with current working sub/directory structure.
Also allows `run_drfs` to create `.bip[.meta]` files as necessary.