### PR TITLE
Regression tests for scag

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,9 @@ Options:
                           Format: YYYY-MM-DD or YYYYMMDD
                           Default: yesterday
 
-  -p, --product [VJ1|VNP|both]
-                          Which VIIRS product to download:
-                          - VJ1: NOAA-20 (VJ109GA_NRT)
-                          - VNP: NPP (VNP09GA_NRT)
-                          - both: Download both products (default)
+  -P, --product TEXT      Product(s) to download. Can be specified multiple
+                          times. Choices: MOD09GA, VNP09GA, VJ109GA
+                          Default: VNP09GA, VJ109GA
 
   -h, --help              Show help message and exit
 ```
@@ -97,13 +95,13 @@ Options:
 ## Download Specific Products
 ```bash
 # Download only VJ109GA (NOAA-20)
-./scripts/fetch-nrt.sh --product VJ1
+./scripts/fetch-nrt.sh --product VJ109GA
 
 # Download only VNP09GA (NPP)
-./scripts/fetch-nrt.sh --product VNP
+./scripts/fetch-nrt.sh --product VNP09GA
 
-# Explicitly download both (same as default)
-./scripts/fetch-nrt.sh --product both
+# Download multiple products
+./scripts/fetch-nrt.sh --product VNP09GA --product VJ109GA
 ```
 
 Files are automatically organized by product and date in separate directories:
@@ -197,6 +195,84 @@ Working directories are organized by product under `$WORK_DIR`:
 └── VJ109GA/
     └── 2026.03.11/h08v04/
 ```
+
+
+## Testing
+
+The test suite lives in `tests/` and is split into three categories. `pytest.ini` at the repo root sets `pythonpath = .` so imports resolve correctly from any directory.
+
+### Unit tests
+
+Tests for path derivation, product registry, and utility helpers. No flags required and no filesystem access needed — safe to run anywhere.
+
+```bash
+pytest tests/test_constants_and_util.py
+```
+
+### DRFS regression tests
+
+Compares DRFS binary outputs (`.bin.mask`, `.bin.Unmask`) against golden reference files stored in PetaLibrary. Tests shape, dtype, pixel-level closeness, value statistics, and masked pixel counts. Tolerances are set for IDL-to-Python comparison (`rtol=1e-3`, `atol=1.0`).
+
+Golden files live at:
+```
+/pl/active/daac-production/drfs_regression/golden/<tile>/
+```
+
+```bash
+pytest tests/test_drfs_regression.py \
+  --date 20260309 \
+  --region onetile \
+  --product MOD09GA
+```
+
+To test exact byte reproducibility between two IDL runs, add `-m idl_only`:
+```bash
+pytest tests/test_drfs_regression.py \
+  --date 20260309 \
+  --region onetile \
+  --product MOD09GA \
+  -m idl_only
+```
+
+### SCAG regression tests
+
+Compares SCAG binary outputs against golden reference files. Tests two stages:
+
+- **Stage 1 — Raw SCAG bins** (output of `scag_sort`, before masking): `grnsz`, `other`, `rms`, `rock`, `shade`, `snow`, `veg`
+- **Stage 2 — Masked/unmasked outputs** (output of `mask_scag`): `GS`, `ICE`, `ROCK`, `SHADE`, `SNOW`, `VEG`, each with `.bin.mask` and `.bin.Unmask` variants
+
+Since SCAG is deterministic Python + binary (no IDL), all tests use exact comparison — byte-for-byte hash is a first-class test, not optional.
+
+Golden files live at:
+```
+/pl/active/daac-production/scag_regression/golden/<tile>/
+```
+
+```bash
+pytest tests/test_scag_regression.py \
+  --date 20260518 \
+  --region onenztile \
+  --product VJ109GA
+```
+
+### Running all tests
+
+```bash
+# Unit tests only (no flags, runs anywhere)
+pytest tests/test_constants_and_util.py
+
+# All regression tests
+pytest tests/test_drfs_regression.py --date 20260309 --region onetile --product MOD09GA
+pytest tests/test_scag_regression.py --date 20260518 --region onenztile --product VJ109GA
+```
+
+Available `--region` values are defined in `src/constants/tiles.ini`:
+```
+WESTERN_US, US_ALASKA, NZ_ALPS, AM_ANDES, US, EUR_ALPS,
+CANADA, AS_HIMILAYA, ARCTIC, AM_SOUTH_CENTRAL, US_HAWAII,
+ATLANTIC_ISLES, ONETILE, ONENZTILE
+```
+
 
 ## Troubleshooting
 

--- a/src/copy_scag_ancillary.py
+++ b/src/copy_scag_ancillary.py
@@ -6,6 +6,7 @@ import re
 import shutil
 from pathlib import Path
 
+from src.constants.paths import TOPDIR
 from src.util import get_sensor_from_filename
 
 
@@ -47,7 +48,7 @@ def get_zenith_degree(bip_meta_file, sun_zenith):
 
 def copy_spectral_library(sensor, working_dir, zenith_degree):
     # copy files
-    scag_config_dir = Path(os.environ.get("SCAG_CONFIG_DIR"))
+    scag_config_dir = TOPDIR / "scag" / "config"
     model_path = scag_config_dir / "models"
     zenith_dir = "z" + str(zenith_degree)
     zenith_path = scag_config_dir / sensor / zenith_dir

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,10 +91,8 @@ def tiles(region) -> list[str]:
 
 @pytest.fixture()
 def golden_dir_for():
-    """Returns a callable: tile -> golden Path."""
-
-    def _get(tile: str) -> Path:
-        path = _PETALIB_DIR / "drfs_regression" / "golden" / tile
+    def _get(tile: str, subdir: str = "drfs_regression/golden") -> Path:
+        path = _PETALIB_DIR / subdir / tile
         if not path.exists():
             pytest.skip(f"Golden directory not found: {path}")
         return path

--- a/tests/test_scag_regression.py
+++ b/tests/test_scag_regression.py
@@ -1,0 +1,428 @@
+"""
+Regression tests for VIIRS SCAG NRT binary output files.
+
+Tests both stages of SCAG output:
+
+    Stage 1 — Raw SCAG bins (output of scag_sort, before masking):
+        grnsz (uint16), other, rms, rock, shade, snow, veg (all uint8)
+        Filenames: VJ109GA_NRT.A{doy}.{tile}.002.{timestamp}.{field}.bin
+
+    Stage 2 — Masked/unmasked outputs (output of mask_scag):
+        GS (uint16), ICE, ROCK, SHADE, SNOW, VEG (all uint8)
+        Each has .bin.mask and .bin.Unmask variants
+        Filenames: VIRSCGDRF_NRT_{field}_{tile}_VJ109GANRT061_{date}_V01.1.bin.{mask_status}
+
+Unlike DRFS, SCAG is pure Python + deterministic binary, so byte-exact
+hash comparison (TestByteHash) IS meaningful for run-to-run reproducibility.
+
+Run with:
+    pytest tests/test_scag_regression.py --date 20260518 --region onenztile --product VJ109GA
+"""
+
+import ast
+import configparser
+import datetime
+import hashlib
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+import pytest
+
+from src.constants.paths import TOPDIR
+from src.constants.products import PRODUCT_TIF_PATTERN
+
+# ---------------------------------------------------------------------------
+# File type configuration
+# ---------------------------------------------------------------------------
+
+# Stage 2: masked/unmasked VIRSCGDRF_NRT output files
+MASKED_FILE_CONFIGS: dict[str, dict] = {
+    "GS": {
+        "dtype": "uint16",
+        "shape": (2400, 2400),
+        "fill_value": 2550,
+        "rtol": 0,
+        "atol": 0,
+    },
+    "ICE": {
+        "dtype": "uint8",
+        "shape": (2400, 2400),
+        "fill_value": 255,
+        "rtol": 0,
+        "atol": 0,
+    },
+    "ROCK": {
+        "dtype": "uint8",
+        "shape": (2400, 2400),
+        "fill_value": 255,
+        "rtol": 0,
+        "atol": 0,
+    },
+    "SHADE": {
+        "dtype": "uint8",
+        "shape": (2400, 2400),
+        "fill_value": 255,
+        "rtol": 0,
+        "atol": 0,
+    },
+    "SNOW": {
+        "dtype": "uint8",
+        "shape": (2400, 2400),
+        "fill_value": 255,
+        "rtol": 0,
+        "atol": 0,
+    },
+    "VEG": {
+        "dtype": "uint8",
+        "shape": (2400, 2400),
+        "fill_value": 255,
+        "rtol": 0,
+        "atol": 0,
+    },
+}
+
+# Stage 1: raw SCAG bin files (before masking)
+RAW_BIN_CONFIGS: dict[str, dict] = {
+    "grnsz": {
+        "dtype": "uint16",
+        "shape": (2400, 2400),
+        "fill_value": None,
+        "rtol": 0,
+        "atol": 0,
+    },
+    "other": {
+        "dtype": "uint8",
+        "shape": (2400, 2400),
+        "fill_value": None,
+        "rtol": 0,
+        "atol": 0,
+    },
+    "rms": {
+        "dtype": "uint8",
+        "shape": (2400, 2400),
+        "fill_value": None,
+        "rtol": 0,
+        "atol": 0,
+    },
+    "rock": {
+        "dtype": "uint8",
+        "shape": (2400, 2400),
+        "fill_value": None,
+        "rtol": 0,
+        "atol": 0,
+    },
+    "shade": {
+        "dtype": "uint8",
+        "shape": (2400, 2400),
+        "fill_value": None,
+        "rtol": 0,
+        "atol": 0,
+    },
+    "snow": {
+        "dtype": "uint8",
+        "shape": (2400, 2400),
+        "fill_value": None,
+        "rtol": 0,
+        "atol": 0,
+    },
+    "veg": {
+        "dtype": "uint8",
+        "shape": (2400, 2400),
+        "fill_value": None,
+        "rtol": 0,
+        "atol": 0,
+    },
+}
+
+VERSION = "V01.1"
+
+
+# ---------------------------------------------------------------------------
+# Variant builders
+# ---------------------------------------------------------------------------
+
+
+def _masked_variants(tile: str, date: str, product: str) -> list[dict]:
+    """VIRSCGDRF_NRT_*.bin.mask / .bin.Unmask variants."""
+    prefix, product_id = PRODUCT_TIF_PATTERN[product]
+    return [
+        {
+            "stage": "masked",
+            "file_type": ft,
+            "masked": masked,
+            "tile": tile,
+            "filename": f"{prefix}_{ft}_{tile}_{product_id}_{date}_{VERSION}"
+            + (".bin.mask" if masked else ".bin.Unmask"),
+            "glob": False,
+        }
+        for ft in MASKED_FILE_CONFIGS
+        for masked in (False, True)
+    ]
+
+
+def _raw_bin_variants(tile: str, date: str) -> list[dict]:
+    """Raw *.bin variants — filename contains a processing timestamp wildcard."""
+    doy = datetime.datetime.strptime(date, "%Y%m%d").strftime("%Y%j")
+    return [
+        {
+            "stage": "raw",
+            "file_type": ft,
+            "masked": False,
+            "tile": tile,
+            # processing timestamp is unknown at test-write time, use glob
+            "filename": f"VJ109GA_NRT.A{doy}.{tile}.002.*.{ft}.bin",
+            "glob": True,
+        }
+        for ft in RAW_BIN_CONFIGS
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve(directory: Path, variant: dict) -> Path:
+    """Resolve a path, handling glob for raw bin files."""
+    if variant["glob"]:
+        matches = list(directory.glob(variant["filename"]))
+        if not matches:
+            return directory / variant["filename"]  # non-existent → fixture will skip
+        return sorted(matches)[0]
+    return directory / variant["filename"]
+
+
+def _load(path: Path, cfg: dict) -> np.ndarray:
+    arr = np.fromfile(path, dtype=cfg["dtype"])
+    rows, cols = cfg["shape"]
+    if arr.size != rows * cols:
+        raise ValueError(
+            f"{path.name}: expected {rows * cols} elements, got {arr.size}"
+        )
+    return arr.reshape(cfg["shape"])
+
+
+def _valid_mask(arr: np.ndarray, fill_value: Optional[int]) -> np.ndarray:
+    mask = np.ones(arr.shape, dtype=bool)
+    if fill_value is not None:
+        mask &= arr != fill_value
+    return mask
+
+
+def _stats(arr: np.ndarray, fill_value: Optional[int]) -> dict:
+    mask = _valid_mask(arr, fill_value)
+    valid = arr[mask]
+    return {
+        "min": float(valid.min()) if valid.size else float("nan"),
+        "max": float(valid.max()) if valid.size else float("nan"),
+        "mean": float(valid.mean()) if valid.size else float("nan"),
+        "std": float(valid.std()) if valid.size else float("nan"),
+        "n_valid": int(mask.sum()),
+        "n_fill": int((~mask).sum()),
+    }
+
+
+def _md5(path: Path) -> str:
+    h = hashlib.md5()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _get_cfg(variant: dict) -> dict:
+    if variant["stage"] == "masked":
+        return MASKED_FILE_CONFIGS[variant["file_type"]]
+    return RAW_BIN_CONFIGS[variant["file_type"]]
+
+
+# ---------------------------------------------------------------------------
+# Tiles loader
+# ---------------------------------------------------------------------------
+
+
+def _load_tiles(region: str) -> list[str]:
+    tiles_ini = TOPDIR / "src" / "constants" / "tiles.ini"
+    if not tiles_ini.exists():
+        raise FileNotFoundError(f"tiles.ini not found at {tiles_ini}")
+    cfg = configparser.RawConfigParser()
+    cfg.optionxform = str  # preserve case
+    cfg.read(tiles_ini)
+    return ast.literal_eval(cfg.get("TILES", region.upper()))
+
+
+# ---------------------------------------------------------------------------
+# Parametrize
+# ---------------------------------------------------------------------------
+
+
+def pytest_generate_tests(metafunc):
+    if "tile_variant" not in metafunc.fixturenames:
+        return
+
+    region = metafunc.config.getoption("--region")
+    date = metafunc.config.getoption("--date")
+    product = metafunc.config.getoption("--product")
+
+    if region is None or date is None:
+        metafunc.parametrize("tile_variant", [])
+        return
+
+    product = product.upper()
+    tiles = _load_tiles(region)
+
+    combos = []
+    for tile in tiles:
+        combos.extend(_masked_variants(tile, date, product))
+        combos.extend(_raw_bin_variants(tile, date))
+
+    ids = [
+        f"{c['tile']}_{c['file_type']}_{'masked' if c['masked'] else 'unmasked'}_{c['stage']}"
+        for c in combos
+    ]
+
+    metafunc.parametrize("tile_variant", combos, ids=ids)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+SCAG_GOLDEN_SUBDIR = "scag_regression/golden"
+
+
+@pytest.fixture()
+def golden_file(tile_variant, golden_dir_for):
+    directory = golden_dir_for(tile_variant["tile"], subdir=SCAG_GOLDEN_SUBDIR)
+    p = _resolve(directory, tile_variant)
+    if not p.exists():
+        pytest.skip(f"Golden file not found: {p}")
+    return p
+
+
+@pytest.fixture()
+def output_file(tile_variant, output_dir_for):
+    directory = output_dir_for(tile_variant["tile"])
+    p = _resolve(directory, tile_variant)
+    if not p.exists():
+        pytest.skip(f"Output file not found: {p}")
+    return p
+
+
+@pytest.fixture()
+def cfg(tile_variant) -> dict:
+    return _get_cfg(tile_variant)
+
+
+@pytest.fixture()
+def arrays(golden_file, output_file, cfg):
+    return _load(golden_file, cfg), _load(output_file, cfg)
+
+
+# ===========================================================================
+# Tests
+# ===========================================================================
+
+
+class TestArrayShape:
+    """Shape and dtype must always match."""
+
+    def test_shape(self, arrays, cfg):
+        golden_arr, output_arr = arrays
+        assert (
+            output_arr.shape == golden_arr.shape
+        ), f"Shape mismatch: expected {golden_arr.shape}, got {output_arr.shape}"
+
+    def test_dtype(self, output_file, cfg):
+        arr = _load(output_file, cfg)
+        assert arr.dtype == np.dtype(
+            cfg["dtype"]
+        ), f"dtype mismatch: expected {cfg['dtype']}, got {arr.dtype}"
+
+
+class TestPixelExact:
+    """
+    Byte-exact pixel comparison.
+
+    SCAG is deterministic Python + binary, so outputs should be
+    exactly reproducible across runs on the same machine.
+    """
+
+    def test_arrays_equal(self, arrays, cfg):
+        golden_arr, output_arr = arrays
+        if not np.array_equal(golden_arr, output_arr):
+            diff = golden_arr.astype(int) - output_arr.astype(int)
+            n_diff = int((diff != 0).sum())
+            pytest.fail(
+                f"Arrays differ in {n_diff:,} pixels.\n"
+                f"  max absolute diff : {np.abs(diff).max()}\n"
+                f"  mean absolute diff: {np.abs(diff).mean():.4g}"
+            )
+
+
+class TestValueStatistics:
+    """Aggregate statistics as a diagnostic when pixel comparison fails."""
+
+    @pytest.fixture(autouse=True)
+    def _compute(self, arrays, cfg):
+        golden_arr, output_arr = arrays
+        self.g = _stats(golden_arr, cfg["fill_value"])
+        self.o = _stats(output_arr, cfg["fill_value"])
+
+    def _assert_equal(self, key: str):
+        assert (
+            self.o[key] == self.g[key]
+        ), f"Statistic '{key}' mismatch: golden={self.g[key]:.6g}, output={self.o[key]:.6g}"
+
+    def test_min(self):
+        self._assert_equal("min")
+
+    def test_max(self):
+        self._assert_equal("max")
+
+    def test_mean(self):
+        self._assert_equal("mean")
+
+    def test_std(self):
+        self._assert_equal("std")
+
+
+class TestMaskedPixelCounts:
+    """Valid and fill pixel counts must match exactly."""
+
+    def test_valid_pixel_count(self, arrays, cfg):
+        golden_arr, output_arr = arrays
+        g = _stats(golden_arr, cfg["fill_value"])
+        o = _stats(output_arr, cfg["fill_value"])
+        assert o["n_valid"] == g["n_valid"], (
+            f"Valid pixel count mismatch: expected {g['n_valid']:,}, got {o['n_valid']:,} "
+            f"(diff={abs(o['n_valid'] - g['n_valid']):,})"
+        )
+
+    def test_fill_pixel_count(self, arrays, cfg):
+        golden_arr, output_arr = arrays
+        g = _stats(golden_arr, cfg["fill_value"])
+        o = _stats(output_arr, cfg["fill_value"])
+        assert o["n_fill"] == g["n_fill"], (
+            f"Fill pixel count mismatch: expected {g['n_fill']:,}, got {o['n_fill']:,} "
+            f"(diff={abs(o['n_fill'] - g['n_fill']):,})"
+        )
+
+
+class TestByteHash:
+    """
+    Byte-for-byte MD5 hash.
+
+    Valid for SCAG (unlike DRFS) because the pipeline is deterministic
+    Python + binary with no floating-point language differences.
+    """
+
+    def test_md5_matches_golden(self, golden_file, output_file):
+        golden_hash = _md5(golden_file)
+        output_hash = _md5(output_file)
+        assert output_hash == golden_hash, (
+            f"MD5 mismatch for {output_file.name}\n"
+            f"  golden : {golden_hash}\n"
+            f"  output : {output_hash}"
+        )


### PR DESCRIPTION
- Added SCAG regression tests — tests/test_scag_regression.py covering 190 test cases across two stages: raw SCAG bins and masked/unmasked VIRSCGDRF_NRT_* outputs for VJ109GA. Unlike DRFS, uses exact comparison throughout since SCAG is deterministic Python + binary.
- Updated README — added Testing section documenting all three test categories with exact commands.
- Fixed found os.environ path thing

resolves #33 